### PR TITLE
Enable globalization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,11 @@ RUN dotnet publish -r linux-musl-x64 -c Release -o /opt/test-runner --no-restore
 
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/runtime-deps:5.0.5-alpine3.13-amd64 AS runtime
+
+# Enable globalization as some exercises use it
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
+RUN apk add --no-cache icu-libs
+
 WORKDIR /opt/test-runner
 
 COPY --from=build /opt/test-runner/ .


### PR DESCRIPTION
Enable globalization. This increases the image size with about 30 MB:

old: 114MB
new: 147MB

Closes https://github.com/exercism/csharp/issues/157


