### PR TITLE
Add tzdata to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ FROM mcr.microsoft.com/dotnet/runtime-deps:5.0.5-alpine3.13-amd64 AS runtime
 # Enable globalization as some exercises use it
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 RUN apk add --no-cache icu-libs
+RUN apk add --no-cache tzdata
 
 WORKDIR /opt/test-runner
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@ FROM mcr.microsoft.com/dotnet/runtime-deps:5.0.5-alpine3.13-amd64 AS runtime
 
 # Enable globalization as some exercises use it
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
-RUN apk add --no-cache icu-libs
-RUN apk add --no-cache tzdata
+RUN apk add --no-cache icu-libs tzdata
 
 WORKDIR /opt/test-runner
 


### PR DESCRIPTION
We have exercises that rely on timezone data to satisfy the tests with a good solution. This adds the timezone information to the runtime docker image so that .net can pick up the timezone information from the container.

I believe this fixes #62 